### PR TITLE
Basic setup of a proposed new format

### DIFF
--- a/clients.md
+++ b/clients.md
@@ -1,0 +1,17 @@
+# A full list of Nostr Clients
+
+## And what they support
+
+| Client         | Repo                                           |
+| :------------- | :--------------------------------------------- |
+| Damus iOS      | https://github.com/damus-io/damus              |
+| Primal iOS     | https://github.com/PrimalHQ/primal-ios-app     |
+| Primal Android | https://github.com/PrimalHQ/primal-android-app |
+| Primal Web     | https://github.com/PrimalHQ/primal-web-app     |
+| Snort          | https://github.com/v0l/snort                   |
+| Iris           | https://github.com/irislib/iris-messenger      |
+| Amethyst       | https://github.com/vitorpamplona/amethyst      |
+| Nostrudel      | https://github.com/hzrd149/nostrudel           |
+| Listr          | https://github.com/erskingardner/listr         |
+| Ostrich.work   | https://github.com/erskingardner/ostrich.work  |
+| Ontolo         | https://github.com/erskingardner/ontolo        |

--- a/clients/_template.md
+++ b/clients/_template.md
@@ -1,0 +1,64 @@
+# Client name
+
+## Supported NIPs
+
+| NIP                                                                | Support | Notes |
+| :----------------------------------------------------------------- | :-----: | :---- |
+| [NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md) |   ✅    |       |
+| [NIP-02](https://github.com/nostr-protocol/nips/blob/master/02.md) |   ❔    |       |
+| [NIP-03](https://github.com/nostr-protocol/nips/blob/master/03.md) |   ❔    |       |
+| [NIP-04](https://github.com/nostr-protocol/nips/blob/master/04.md) |   ❔    |       |
+| [NIP-05](https://github.com/nostr-protocol/nips/blob/master/05.md) |   ❔    |       |
+| [NIP-06](https://github.com/nostr-protocol/nips/blob/master/06.md) |   ❔    |       |
+| [NIP-07](https://github.com/nostr-protocol/nips/blob/master/07.md) |   ❔    |       |
+| [NIP-08](https://github.com/nostr-protocol/nips/blob/master/08.md) |   ❔    |       |
+| [NIP-09](https://github.com/nostr-protocol/nips/blob/master/09.md) |   ❔    |       |
+| [NIP-10](https://github.com/nostr-protocol/nips/blob/master/10.md) |   ❔    |       |
+| [NIP-11](https://github.com/nostr-protocol/nips/blob/master/11.md) |   ❔    |       |
+| [NIP-12](https://github.com/nostr-protocol/nips/blob/master/12.md) |   ❔    |       |
+| [NIP-13](https://github.com/nostr-protocol/nips/blob/master/13.md) |   ❔    |       |
+| [NIP-14](https://github.com/nostr-protocol/nips/blob/master/14.md) |   ❔    |       |
+| [NIP-15](https://github.com/nostr-protocol/nips/blob/master/15.md) |   ❔    |       |
+| [NIP-16](https://github.com/nostr-protocol/nips/blob/master/16.md) |   ❔    |       |
+| [NIP-18](https://github.com/nostr-protocol/nips/blob/master/18.md) |   ❔    |       |
+| [NIP-19](https://github.com/nostr-protocol/nips/blob/master/19.md) |   ❔    |       |
+| [NIP-20](https://github.com/nostr-protocol/nips/blob/master/20.md) |   ❔    |       |
+| [NIP-21](https://github.com/nostr-protocol/nips/blob/master/21.md) |   ❔    |       |
+| [NIP-23](https://github.com/nostr-protocol/nips/blob/master/23.md) |   ❔    |       |
+| [NIP-24](https://github.com/nostr-protocol/nips/blob/master/24.md) |   ❔    |       |
+| [NIP-25](https://github.com/nostr-protocol/nips/blob/master/25.md) |   ❔    |       |
+| [NIP-26](https://github.com/nostr-protocol/nips/blob/master/26.md) |   ❔    |       |
+| [NIP-27](https://github.com/nostr-protocol/nips/blob/master/27.md) |   ❔    |       |
+| [NIP-28](https://github.com/nostr-protocol/nips/blob/master/28.md) |   ❔    |       |
+| [NIP-30](https://github.com/nostr-protocol/nips/blob/master/30.md) |   ❔    |       |
+| [NIP-31](https://github.com/nostr-protocol/nips/blob/master/31.md) |   ❔    |       |
+| [NIP-32](https://github.com/nostr-protocol/nips/blob/master/32.md) |   ❔    |       |
+| [NIP-33](https://github.com/nostr-protocol/nips/blob/master/33.md) |   ❔    |       |
+| [NIP-36](https://github.com/nostr-protocol/nips/blob/master/36.md) |   ❔    |       |
+| [NIP-38](https://github.com/nostr-protocol/nips/blob/master/38.md) |   ❔    |       |
+| [NIP-39](https://github.com/nostr-protocol/nips/blob/master/39.md) |   ❔    |       |
+| [NIP-40](https://github.com/nostr-protocol/nips/blob/master/40.md) |   ❔    |       |
+| [NIP-42](https://github.com/nostr-protocol/nips/blob/master/42.md) |   ❔    |       |
+| [NIP-44](https://github.com/nostr-protocol/nips/blob/master/44.md) |   ❔    |       |
+| [NIP-45](https://github.com/nostr-protocol/nips/blob/master/45.md) |   ❔    |       |
+| [NIP-46](https://github.com/nostr-protocol/nips/blob/master/46.md) |   ❔    |       |
+| [NIP-47](https://github.com/nostr-protocol/nips/blob/master/47.md) |   ❔    |       |
+| [NIP-48](https://github.com/nostr-protocol/nips/blob/master/48.md) |   ❔    |       |
+| [NIP-50](https://github.com/nostr-protocol/nips/blob/master/50.md) |   ❔    |       |
+| [NIP-51](https://github.com/nostr-protocol/nips/blob/master/51.md) |   ❔    |       |
+| [NIP-52](https://github.com/nostr-protocol/nips/blob/master/52.md) |   ❔    |       |
+| [NIP-53](https://github.com/nostr-protocol/nips/blob/master/53.md) |   ❔    |       |
+| [NIP-56](https://github.com/nostr-protocol/nips/blob/master/56.md) |   ❔    |       |
+| [NIP-57](https://github.com/nostr-protocol/nips/blob/master/57.md) |   ❔    |       |
+| [NIP-58](https://github.com/nostr-protocol/nips/blob/master/58.md) |   ❔    |       |
+| [NIP-65](https://github.com/nostr-protocol/nips/blob/master/65.md) |   ❔    |       |
+| [NIP-72](https://github.com/nostr-protocol/nips/blob/master/72.md) |   ❔    |       |
+| [NIP-75](https://github.com/nostr-protocol/nips/blob/master/75.md) |   ❔    |       |
+| [NIP-78](https://github.com/nostr-protocol/nips/blob/master/78.md) |   ❔    |       |
+| [NIP-84](https://github.com/nostr-protocol/nips/blob/master/84.md) |   ❔    |       |
+| [NIP-89](https://github.com/nostr-protocol/nips/blob/master/89.md) |   ❔    |       |
+| [NIP-90](https://github.com/nostr-protocol/nips/blob/master/90.md) |   ❔    |       |
+| [NIP-94](https://github.com/nostr-protocol/nips/blob/master/94.md) |   ❔    |       |
+| [NIP-96](https://github.com/nostr-protocol/nips/blob/master/96.md) |   ❔    |       |
+| [NIP-98](https://github.com/nostr-protocol/nips/blob/master/98.md) |   ❔    |       |
+| [NIP-99](https://github.com/nostr-protocol/nips/blob/master/99.md) |   ❔    |       |

--- a/clients/damus-ios.md
+++ b/clients/damus-ios.md
@@ -1,0 +1,64 @@
+# Damus iOS
+
+## Supported NIPs
+
+| NIP                                                                | Support | Notes |
+| :----------------------------------------------------------------- | :-----: | :---- |
+| [NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md) |   ✅    |       |
+| [NIP-02](https://github.com/nostr-protocol/nips/blob/master/02.md) |   ❔    |       |
+| [NIP-03](https://github.com/nostr-protocol/nips/blob/master/03.md) |   ❔    |       |
+| [NIP-04](https://github.com/nostr-protocol/nips/blob/master/04.md) |   ❔    |       |
+| [NIP-05](https://github.com/nostr-protocol/nips/blob/master/05.md) |   ❔    |       |
+| [NIP-06](https://github.com/nostr-protocol/nips/blob/master/06.md) |   ❔    |       |
+| [NIP-07](https://github.com/nostr-protocol/nips/blob/master/07.md) |   ❔    |       |
+| [NIP-08](https://github.com/nostr-protocol/nips/blob/master/08.md) |   ❔    |       |
+| [NIP-09](https://github.com/nostr-protocol/nips/blob/master/09.md) |   ❔    |       |
+| [NIP-10](https://github.com/nostr-protocol/nips/blob/master/10.md) |   ❔    |       |
+| [NIP-11](https://github.com/nostr-protocol/nips/blob/master/11.md) |   ❔    |       |
+| [NIP-12](https://github.com/nostr-protocol/nips/blob/master/12.md) |   ❔    |       |
+| [NIP-13](https://github.com/nostr-protocol/nips/blob/master/13.md) |   ❔    |       |
+| [NIP-14](https://github.com/nostr-protocol/nips/blob/master/14.md) |   ❔    |       |
+| [NIP-15](https://github.com/nostr-protocol/nips/blob/master/15.md) |   ❔    |       |
+| [NIP-16](https://github.com/nostr-protocol/nips/blob/master/16.md) |   ❔    |       |
+| [NIP-18](https://github.com/nostr-protocol/nips/blob/master/18.md) |   ❔    |       |
+| [NIP-19](https://github.com/nostr-protocol/nips/blob/master/19.md) |   ❔    |       |
+| [NIP-20](https://github.com/nostr-protocol/nips/blob/master/20.md) |   ❔    |       |
+| [NIP-21](https://github.com/nostr-protocol/nips/blob/master/21.md) |   ❔    |       |
+| [NIP-23](https://github.com/nostr-protocol/nips/blob/master/23.md) |   ❔    |       |
+| [NIP-24](https://github.com/nostr-protocol/nips/blob/master/24.md) |   ❔    |       |
+| [NIP-25](https://github.com/nostr-protocol/nips/blob/master/25.md) |   ❔    |       |
+| [NIP-26](https://github.com/nostr-protocol/nips/blob/master/26.md) |   ❔    |       |
+| [NIP-27](https://github.com/nostr-protocol/nips/blob/master/27.md) |   ❔    |       |
+| [NIP-28](https://github.com/nostr-protocol/nips/blob/master/28.md) |   ❔    |       |
+| [NIP-30](https://github.com/nostr-protocol/nips/blob/master/30.md) |   ❔    |       |
+| [NIP-31](https://github.com/nostr-protocol/nips/blob/master/31.md) |   ❔    |       |
+| [NIP-32](https://github.com/nostr-protocol/nips/blob/master/32.md) |   ❔    |       |
+| [NIP-33](https://github.com/nostr-protocol/nips/blob/master/33.md) |   ❔    |       |
+| [NIP-36](https://github.com/nostr-protocol/nips/blob/master/36.md) |   ❔    |       |
+| [NIP-38](https://github.com/nostr-protocol/nips/blob/master/38.md) |   ❔    |       |
+| [NIP-39](https://github.com/nostr-protocol/nips/blob/master/39.md) |   ❔    |       |
+| [NIP-40](https://github.com/nostr-protocol/nips/blob/master/40.md) |   ❔    |       |
+| [NIP-42](https://github.com/nostr-protocol/nips/blob/master/42.md) |   ❔    |       |
+| [NIP-44](https://github.com/nostr-protocol/nips/blob/master/44.md) |   ❔    |       |
+| [NIP-45](https://github.com/nostr-protocol/nips/blob/master/45.md) |   ❔    |       |
+| [NIP-46](https://github.com/nostr-protocol/nips/blob/master/46.md) |   ❔    |       |
+| [NIP-47](https://github.com/nostr-protocol/nips/blob/master/47.md) |   ❔    |       |
+| [NIP-48](https://github.com/nostr-protocol/nips/blob/master/48.md) |   ❔    |       |
+| [NIP-50](https://github.com/nostr-protocol/nips/blob/master/50.md) |   ❔    |       |
+| [NIP-51](https://github.com/nostr-protocol/nips/blob/master/51.md) |   ❔    |       |
+| [NIP-52](https://github.com/nostr-protocol/nips/blob/master/52.md) |   ❔    |       |
+| [NIP-53](https://github.com/nostr-protocol/nips/blob/master/53.md) |   ❔    |       |
+| [NIP-56](https://github.com/nostr-protocol/nips/blob/master/56.md) |   ❔    |       |
+| [NIP-57](https://github.com/nostr-protocol/nips/blob/master/57.md) |   ❔    |       |
+| [NIP-58](https://github.com/nostr-protocol/nips/blob/master/58.md) |   ❔    |       |
+| [NIP-65](https://github.com/nostr-protocol/nips/blob/master/65.md) |   ❔    |       |
+| [NIP-72](https://github.com/nostr-protocol/nips/blob/master/72.md) |   ❔    |       |
+| [NIP-75](https://github.com/nostr-protocol/nips/blob/master/75.md) |   ❔    |       |
+| [NIP-78](https://github.com/nostr-protocol/nips/blob/master/78.md) |   ❔    |       |
+| [NIP-84](https://github.com/nostr-protocol/nips/blob/master/84.md) |   ❔    |       |
+| [NIP-89](https://github.com/nostr-protocol/nips/blob/master/89.md) |   ❔    |       |
+| [NIP-90](https://github.com/nostr-protocol/nips/blob/master/90.md) |   ❔    |       |
+| [NIP-94](https://github.com/nostr-protocol/nips/blob/master/94.md) |   ❔    |       |
+| [NIP-96](https://github.com/nostr-protocol/nips/blob/master/96.md) |   ❔    |       |
+| [NIP-98](https://github.com/nostr-protocol/nips/blob/master/98.md) |   ❔    |       |
+| [NIP-99](https://github.com/nostr-protocol/nips/blob/master/99.md) |   ❔    |       |

--- a/nips/nip-89.md
+++ b/nips/nip-89.md
@@ -1,0 +1,19 @@
+# NIP-89
+
+## Recommended Application Handlers
+
+[NIPs repo: NIP-89](https://github.com/nostr-protocol/nips/blob/master/89.md)
+
+| Client         | Support | Source                             | Repo                                           |
+| :------------- | :-----: | :--------------------------------- | :--------------------------------------------- |
+| Damus iOS      |   ❌    |                                    | https://github.com/damus-io/damus              |
+| Primal iOS     |   ❌    |                                    | https://github.com/PrimalHQ/primal-ios-app     |
+| Primal Android |   ❌    |                                    | https://github.com/PrimalHQ/primal-android-app |
+| Primal Web     |   ❌    |                                    | https://github.com/PrimalHQ/primal-web-app     |
+| Snort          |   ❌    | https://github.com/v0l/snort       | https://github.com/v0l/snort                   |
+| Iris           |   ❔    |                                    | https://github.com/irislib/iris-messenger      |
+| Amethyst       |   ❔    |                                    | https://github.com/vitorpamplona/amethyst      |
+| Nostrudel      |   ❔    |                                    | https://github.com/hzrd149/nostrudel           |
+| Listr          |   ❌    | [@jeffg](https://primal.net/jeffg) | https://github.com/erskingardner/listr         |
+| Ostrich.work   |   ❌    | [@jeffg](https://primal.net/jeffg) | https://github.com/erskingardner/ostrich.work  |
+| Ontolo         |   ❌    | [@jeffg](https://primal.net/jeffg) | https://github.com/erskingardner/ontolo        |


### PR DESCRIPTION
@alltheseas I started a branch just to play around with potential formatting here. In the process though I think that this will just be waaaaaaay to hard to keep up to date. 

I have another idea and would love your feedback (and yours @staab). What if we build a super simple app that pulls data directly from the NIPs repo, keeps small database of clients and what they support. Then we can crowdsource people filling in the details of who supports what and hopefully keep a record that stays up to date with super minimal effort on the part of devs.

A few ideas: 
- Send emails to devs (identified by commit messages on their repos) when new NIPs are added or changed significantly.
- Allow people to subscribe to the supported features
- Use the data to generate massive feature tables showing who supports what

Am I just being way too overly optimistic that this could work? 